### PR TITLE
fix: support v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
@@ -31,6 +32,6 @@ jobs:
       - name: Publish to npm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vitest": "^3.1.1"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": ">= 5.0.0"
       }
     },
     "node_modules/@andrewbranch/untar.js": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,12 @@
   },
   "homepage": "https://github.com/MarioCadenas/vite-plugin-css-sourcemap#readme",
   "description": "A Vite plugin to generate CSS sourcemaps",
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "peerDependencies": {
-    "vite": "^5.0.0 || ^6.0.0"
+    "vite": ">= 5.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -15,7 +15,7 @@ const gitPlugin = {
 
 export default {
   verifyConditions: [npmPlugin, githubPlugin],
-  prepare: [npmPlugin, changelogPlugin, gitPlugin],
+  prepare: [changelogPlugin, npmPlugin, gitPlugin],
   publish: [npmPlugin, githubPlugin],
   success: [githubPlugin],
   fail: [githubPlugin],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates release and publishing setup and relaxes Vite peer range.
> 
> - Adds `publishConfig` with `provenance: true` and `access: public` in `package.json`; sets `NPM_CONFIG_PROVENANCE: true` and removes `NPM_TOKEN` in `release.yml`; sets job `environment: release`
> - Relaxes `peerDependencies.vite` to `>= 5.0.0` (lockfile updated accordingly)
> - Reorders semantic-release `prepare` plugins to `[changelog, npm, git]` in `release.config.mjs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e6bae2a29d703a05c786bfb864dee027a0e82fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->